### PR TITLE
Add runtime check to workflow

### DIFF
--- a/.github/workflows/orologic.yml
+++ b/.github/workflows/orologic.yml
@@ -88,8 +88,30 @@ jobs:
             --hidden-import chess.engine \
             --hidden-import pyperclip \
             --hidden-import dateutil.relativedelta \
-            orologic_pt.py
+          orologic_pt.py
         fi
+      shell: bash
+
+    - name: Test executable
+      run: |
+        python - <<'EOF'
+        import subprocess, sys, time
+        if sys.platform.startswith('win'):
+            cmd = [r'dist\\Orologic.exe']
+        elif sys.platform.startswith('darwin'):
+            cmd = ['dist/Orologic.app/Contents/MacOS/Orologic']
+        else:
+            cmd = ['./dist/Orologic']
+        try:
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            time.sleep(3)
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception as e:
+            print('Executable failed to run:', e)
+            sys.exit(1)
+        sys.exit(0 if proc.returncode in (0, None, 143) else proc.returncode)
+        EOF
       shell: bash
 
     - name: Create macOS DMG


### PR DESCRIPTION
## Summary
- ensure built executables are run briefly to detect failures

## Testing
- `python -m py_compile orologic_pt.py`


------
https://chatgpt.com/codex/tasks/task_e_686cadd04400832681c46c3d732c7154